### PR TITLE
Update the modified time of the macOS app bundle per deploy

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -167,6 +167,9 @@ namespace osu.Desktop.Deploy
                     // unzip the template app, with all structure existing except for dotnet published content.
                     runCommand("unzip", $"\"osu!.app-template.zip\" -d {stagingPath}", false);
 
+                    // without touching the app bundle itself, changes to file associations / icons / etc. will be cached at a macOS level and not updated.
+                    runCommand("touch" ,$"\"{Path.Combine(stagingPath, "osu!.app")}\" -d {stagingPath}", false);
+
                     runCommand("dotnet", $"publish -r osx-x64 {ProjectName} --configuration Release -o {stagingPath}/osu!.app/Contents/MacOS /p:Version={version}");
 
                     string stagingApp = $"{stagingPath}/osu!.app";
@@ -174,7 +177,6 @@ namespace osu.Desktop.Deploy
 
                     // correct permissions post-build. dotnet outputs 644 by default; we want 755.
                     runCommand("chmod", $"-R 755 {stagingApp}");
-
 
                     if (!string.IsNullOrEmpty(CodeSigningCertificate))
                     {


### PR DESCRIPTION
Was pointed out by @p00ya as a potential issue when working through #101.  Since are are taking this straight from the `zip` until now, it was using the original timestamp until now.

Before:

```
osu-deploy/staging on  master
❯ ls -la
total 0
drwxr-xr-x   4 dean  staff  128 Aug 23 16:46 .
drwxr-xr-x  28 dean  staff  896 Aug 23 16:46 ..
drwxr-xr-x   3 dean  staff   96 Aug 23 16:46 __MACOSX
drwxr-xr-x   3 dean  staff   96 Jul 11  2018 osu!.app
```

After:

```
osu-deploy/staging on  master
❯ ls -la
total 0
drwxr-xr-x   4 dean  staff  128 Aug 23 16:44 .
drwxr-xr-x  28 dean  staff  896 Aug 23 16:45 ..
drwxr-xr-x   3 dean  staff   96 Aug 23 16:44 __MACOSX
drwxr-xr-x   3 dean  staff   96 Aug 23 16:44 osu!.app
```
