### PR TITLE
Fixed issues with parsing of command line arguments on Linux

### DIFF
--- a/templates/osu!.AppDir/AppRun
+++ b/templates/osu!.AppDir/AppRun
@@ -10,4 +10,4 @@ fi
 HERE="$(dirname "$(readlink -f "${0}")")"
 export PATH="${HERE}"/usr/bin/:"${PATH}"
 EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2 | cut -d " " -f 1)
-exec "${EXEC}" $@
+exec "${EXEC}" "$@"


### PR DESCRIPTION
Quotation marks were missing in the AppRun file