### PR TITLE
Remove malformed Path option from AppDir desktop entry

### DIFF
--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -5,7 +5,6 @@ Name=osu!
 Comment=A free-to-win rhythm game. Rhythm is just a *click* away!
 Icon=osu!
 Exec=osu!
-Path=~
 Terminal=false
 Categories=Game;
 


### PR DESCRIPTION
As mentioned in ppy/osu#18023, `~` is not supported in `Path`, and having it causes problems when trying to run this desktop entry - I presume it is interpreted literally and as there is no such directory with that name, it will will fail to set working directory and will not launch the application.
As it is not a required field in the spec, and based on my testing, setting the working directory to `$HOME` is not needed for osu! to run, I think it can be removed.