### PR TITLE
Changed download of appimagetool to stable version

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -242,7 +242,7 @@ namespace osu.Desktop.Deploy
 
                     using (var client = new HttpClient())
                     {
-                        using (var stream = client.GetStreamAsync("https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage").GetResultSafely())
+                        using (var stream = client.GetStreamAsync("https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage").GetResultSafely())
                         using (var fileStream = new FileStream(appImageToolPath, FileMode.CreateNew))
                         {
                             stream.CopyToAsync(fileStream).WaitSafely();


### PR DESCRIPTION
Split from #134 to address the signing [issue](https://github.com/ppy/osu/issues/19780)

The bug in the appimagetool got fixed in response to my ticket but not relying on continuous builds might still be a good idea.