### PR TITLE
Add GC stutter workaround into AppImages

### DIFF
--- a/templates/osu!.AppDir/AppRun
+++ b/templates/osu!.AppDir/AppRun
@@ -9,5 +9,6 @@ fi
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 export PATH="${HERE}"/usr/bin/:"${PATH}"
-EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2 | cut -d " " -f 1)
+export COMPlus_GCGen0MaxBudget=600000
+EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | rev | cut -d "=" -f 1 | cut -d " " -f 1 | rev)
 exec "${EXEC}" "$@"

--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -4,7 +4,7 @@ Type=Application
 Name=osu!
 Comment=A free-to-win rhythm game. Rhythm is just a *click* away!
 Icon=osu!
-Exec=osu!
+Exec=env COMPlus_GCGen0MaxBudget=600000 osu!
 Terminal=false
 Categories=Game;
 


### PR DESCRIPTION
Makes 2 changes to add the workaround recommended in [an osu! issue](https://github.com/ppy/osu/issues/11800) to reduce stuttering on linux machines caused by GC. (this was discussed on sunday)

The changes are as follows:
- Add the required environment variable into both the .desktop and AppRun
- Make AppRun capable of parsing both the `Exec=osu!` and `Exec=env a=b osu!` syntax in .desktop by taking the first value from the end post-equals-sign-split instead of the second one from the beginning