### PR TITLE
 Add SingleMainWindow=true to desktop file

### DIFF
--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -7,4 +7,4 @@ Icon=osu!
 Exec=env COMPlus_GCGen0MaxBudget=600000 osu!
 Terminal=false
 Categories=Game;
-
+SingleMainWindow=true


### PR DESCRIPTION
This indicates only one application can be opened at the same time, and will hide "Open New Window" menu action in Plasma Desktop.