### PR TITLE
Fix linux deploys failing on desktop file validation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -242,7 +242,7 @@ namespace osu.Desktop.Deploy
 
                     using (var client = new HttpClient())
                     {
-                        using (var stream = client.GetStreamAsync("https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage").GetResultSafely())
+                        using (var stream = client.GetStreamAsync("https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage").GetResultSafely())
                         using (var fileStream = new FileStream(appImageToolPath, FileMode.CreateNew))
                         {
                             stream.CopyToAsync(fileStream).WaitSafely();

--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -1,5 +1,6 @@
 # Desktop Entry Specification: https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
 [Desktop Entry]
+Version=1.5
 Type=Application
 Name=osu!
 Comment=A free-to-win rhythm game. Rhythm is just a *click* away!


### PR DESCRIPTION
The `SingleMainWindow` key added to `osu!.desktop` in #145 has been added to the Desktop Entry Specification in version 1.5 [[1]]. `appimagetool` was using an older version of `desktop-file-validate` that only understood version 1.0 [[2]], thus leading to deployment failure.

To fix, update `appimagetool` from release 13 to the continuous build to receive the upstream fixes from [[2]], as well as explicitly specify the Desktop Entry Specification version in the `osu!.desktop` file template.

[1]: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#idm45828204418512
[2]: https://github.com/AppImage/AppImageKit/issues/1171