### PR TITLE
Fix console colour not being reset after printing deployment error

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -686,6 +686,7 @@ namespace osu.Desktop.Deploy
         {
             Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine($"FATAL ERROR: {message}");
+            Console.ResetColor();
 
             pauseIfInteractive();
             Environment.Exit(-1);


### PR DESCRIPTION
My console gets rather red in a rather permanent manner after a deployment error without this.

(If you're wondering what I'm even doing in there, the answer is attempting to test https://github.com/ppy/osu/pull/25385.)