### PR TITLE
add StartupWMClass

### DIFF
--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -9,3 +9,4 @@ Exec=env COMPlus_GCGen0MaxBudget=600000 osu!
 Terminal=false
 Categories=Game;
 SingleMainWindow=true
+StartupWMClass=osu!

--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -8,5 +8,5 @@ Icon=osu!
 Exec=env COMPlus_GCGen0MaxBudget=600000 osu!
 Terminal=false
 Categories=Game;
-SingleMainWindow=true
 StartupWMClass=osu!
+SingleMainWindow=true


### PR DESCRIPTION
`.desktop` files support a field named `StartupWMClass` which indicates the internal WM Class (Window Manager Class) ID of the window, so that desktop environments can realize what that `.desktop` file had launched and associate that open window with it.

This is a crucial part of the desktop integration, GNOME for example highlights the app icon with a little indicator that says there is already an open window and so attempting to open the app again simply jumps to the active window instead.

Another example is pinning the app to the dock, you pin the `.desktop` file but when the app is opened, there will be a duplicate icon in the dock, due to the window manager not being able to associate the actual opened window with the pinned `.desktop` file.

This image shows a screenshot of GNOME's `looking-glass` utility which can be used to inspect internal window details.

![Screenshot from 2024-01-14 19-21-54](https://github.com/ppy/osu-deploy/assets/31079629/586372ad-9514-4a3f-b4ef-696eb756e934)

as you can see all apps have their internal WM class but the other apps do connect that class with their `.desktop` file so GNOME perfectly knows which `.desktop` file is associated with that window, while osu! is marked as `<untracked>`. This PR addresses that missing field.

Keep in mind this has no effect if the user is just downloading the `.AppImage` and running it, this issue addresses 'desktop integration' which assumes files like the `.desktop` file gets 'installed' to the user's system so the desktop is aware of such details of the application. Many solutions exist to integrate AppImages and so it's always better if the AppImage is also ready to respond for a complete desktop integration. I'll be addressing a couple more of this type of issues in the coming days to improve desktop integration on Linux.