### PR TITLE
Add `--self-contained` to publish command

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -147,7 +147,7 @@ namespace osu.Desktop.Deploy
                     if (lastRelease != null)
                         getAssetsFromRelease(lastRelease);
 
-                    runCommand("dotnet", $"publish -f net8.0 -r win-x64 {ProjectName} -o \"{stagingPath}\" --configuration Release /p:Version={version}");
+                    runCommand("dotnet", $"publish -f net8.0 -r win-x64 {ProjectName} -o \"{stagingPath}\" --configuration Release /p:Version={version} --self-contained");
 
                     // add icon to dotnet stub
                     runCommand("tools/rcedit-x64.exe", $"\"{stagingPath}\\osu!.exe\" --set-icon \"{iconPath}\"");
@@ -370,7 +370,7 @@ namespace osu.Desktop.Deploy
             // without touching the app bundle itself, changes to file associations / icons / etc. will be cached at a macOS level and not updated.
             runCommand("touch", $"\"{Path.Combine(stagingPath, "osu!.app")}\" {stagingPath}", false);
 
-            runCommand("dotnet", $"publish -f net8.0 -r osx-{arch} {ProjectName} --configuration Release -o {stagingPath}/osu!.app/Contents/MacOS /p:Version={version}");
+            runCommand("dotnet", $"publish -f net8.0 -r osx-{arch} {ProjectName} --configuration Release -o {stagingPath}/osu!.app/Contents/MacOS /p:Version={version} --self-contained");
 
             string stagingApp = $"{stagingPath}/osu!.app";
             string archLabel = arch == "x64" ? "Intel" : "Apple Silicon";


### PR DESCRIPTION
In .NET7+ the default was changed to `false`.