### PR TITLE
Improve error messaging when locating tools fails

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -678,12 +678,16 @@ namespace osu.Desktop.Deploy
         {
             var process = Process.Start(new ProcessStartInfo("dotnet", "list osu.Desktop.Deploy.csproj package")
             {
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
             });
 
             Debug.Assert(process != null);
 
             process.WaitForExit();
+
+            if (process.ExitCode != 0)
+                throw new InvalidOperationException($"Could not locate tool {toolExecutable}!\nStandard error: {process.StandardError.ReadToEnd()}");
 
             string output = process.StandardOutput.ReadToEnd();
 


### PR DESCRIPTION
The subprocess run of `dotnet list package` didn't have exit code checking, so it'd fail silently if anything inside dotnet fell over. For better experience, check the exit code of dotnet and throw if it's not zero, additionally appending stdout from the command for convenience.

I hit this locally in testing of other changes. Cause of failure was incorrect working directory spec.