### PR TITLE
Remove GC stutter workaround in AppImages

### DIFF
--- a/templates/osu!.AppDir/AppRun
+++ b/templates/osu!.AppDir/AppRun
@@ -9,6 +9,5 @@ fi
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 export PATH="${HERE}"/usr/bin/:"${PATH}"
-export COMPlus_GCGen0MaxBudget=600000
 EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | rev | cut -d "=" -f 1 | cut -d " " -f 1 | rev)
 exec "${EXEC}" "$@"

--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -5,7 +5,7 @@ Type=Application
 Name=osu!
 Comment=A free-to-win rhythm game. Rhythm is just a *click* away!
 Icon=osu!
-Exec=env COMPlus_GCGen0MaxBudget=600000 osu!
+Exec=osu!
 Terminal=false
 Categories=Game;
 StartupWMClass=osu!


### PR DESCRIPTION
This workaround doesn't seem to be necessary anymore after the GC changes in the last update. Tested locally without the workaround and didn't notice any stutter being reintroduced