### PR TITLE
Fix incorrect authors argument name

### DIFF
--- a/Uploaders/VelopackUploader.cs
+++ b/Uploaders/VelopackUploader.cs
@@ -48,7 +48,7 @@ namespace osu.Desktop.Deploy.Uploaders
         {
             Program.RunCommand("dotnet", $"vpk [{operatingSystemName}] pack"
                                          + $" --packTitle=\"{PackTitle}\""
-                                         + $" --packAuthor=\"ppy Pty Ltd\""
+                                         + $" --packAuthors=\"ppy Pty Ltd\""
                                          + $" --packId=\"{Program.PackageName}\""
                                          + $" --packVersion=\"{version}\""
                                          + $" --runtime=\"{runtimeIdentifier}\""


### PR DESCRIPTION
The only reference to this argument in the wiki is [`--packAuthor`](https://docs.velopack.io/integrating/shortcuts), but the command is actually [`--packAuthors`](https://github.com/velopack/velopack/blob/ca71471cbd9893f2510c06ecd14225751d6b8116/src/vpk/Velopack.Vpk/Commands/_PackCommand.cs#L78-L80).

Proof:
```
33613   Running dotnet vpk [linux] pack --packTitle="osu!" --packAuthor="ppy Pty Ltd" --packId="osulazer" --packVersion="2024.911.0" --runtime="linux-x64" --outputDir="C:\Users\smoog\Repos\osu-deploy\releases" --mainExe="osu!" --packDir="C:\Users\smoog\Repos\osu-deploy\staging\osu!.AppDir" --channel="linux-x64" ...
34372   [04:49:50 INF] Directive enabled for cross-compiling from Windows (current os) to Linux.

Unrecognized command or argument '--packAuthor=ppy Pty Ltd'.
```