### PR TITLE
Update linux desktop file

### DIFF
--- a/templates/osu!.AppDir/AppRun
+++ b/templates/osu!.AppDir/AppRun
@@ -9,5 +9,5 @@ fi
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 export PATH="${HERE}"/usr/bin/:"${PATH}"
-EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | rev | cut -d "=" -f 1 | cut -d " " -f 1 | rev)
+EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2 | cut -d " " -f 1)
 exec "${EXEC}" "$@"

--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -1,13 +1,14 @@
 # Desktop Entry Specification: https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
 [Desktop Entry]
-Version=1.5
+Version=1.6
 Type=Application
 Name=osu!
 Comment=A free-to-win rhythm game. Rhythm is just a *click* away!
 Icon=osu!
-Exec=osu!
+Exec=osu! %u
 Terminal=false
 MimeType=application/x-osu-beatmap-archive;application/x-osu-skin-archive;application/x-osu-beatmap;application/x-osu-storyboard;application/x-osu-replay;x-scheme-handler/osu;
 Categories=Game;
 StartupWMClass=osu!
 SingleMainWindow=true
+StartupNotify=true

--- a/templates/osu!.AppDir/osu!.desktop
+++ b/templates/osu!.AppDir/osu!.desktop
@@ -1,6 +1,6 @@
 # Desktop Entry Specification: https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
 [Desktop Entry]
-Version=1.6
+Version=1.5
 Type=Application
 Name=osu!
 Comment=A free-to-win rhythm game. Rhythm is just a *click* away!


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10423

Adding a `%u` at the end of `Exec` should allow both files and urls to be passed to the AppImage (given it gets integrated into the system using `AppImageLauncher` or the like). This would allow for `osu://` links to be handled properly. It might also be a good idea to add some installation instructions for linux users to use an AppImage launcher if they want mime types & associations to be set up, maybe somewhere in the README? Not sure.

I also added `StartupNotify=true` to notify the user (focus lazer & bring it to the top) when it opens. Given that lazer's startup time on Linux has gone up with Velopack, I figure it's a good idea to focus lazer when it's ready.

I haven't tested this yet, so I'm going to be cautious and open as a draft until I do that. I'm slightly concerned about how it'll play out with this line: https://github.com/ppy/osu-deploy/blob/96ece8e5095ec421d3d116883747b136c1033033/templates/osu!.AppDir/AppRun#L12

Feel free to leave any comments