### PR TITLE
Fix iOS package name

### DIFF
--- a/Builders/IOSBuilder.cs
+++ b/Builders/IOSBuilder.cs
@@ -22,7 +22,7 @@ namespace osu.Desktop.Deploy.Builders
         {
             RunDotnetPublish("-p:ApplicationDisplayVersion=1.0");
 
-            File.Move(Path.Combine(Program.StagingPath, "osu.iOS.app"), Path.Combine(Program.ReleasesPath, "osu.iOS.app"), true);
+            File.Move(Path.Combine(Program.StagingPath, "osu.iOS.ipa"), Path.Combine(Program.ReleasesPath, "osu.iOS.ipa"), true);
         }
     }
 }


### PR DESCRIPTION
This was broken in https://github.com/ppy/osu-deploy/commit/243bb7d6f626e76faae69f39793c94ebf8974b97 prior to my refactoring, and I didn't notice it.