### PR TITLE
Use zlib compression for now

### DIFF
--- a/Builders/LinuxBuilder.cs
+++ b/Builders/LinuxBuilder.cs
@@ -25,7 +25,14 @@ namespace osu.Desktop.Deploy.Builders
         protected override string TargetFramework => "net8.0";
         protected override string RuntimeIdentifier => $"{os_name}-x64";
 
-        public override Uploader CreateUploader() => new LinuxVelopackUploader(app_name, os_name, RuntimeIdentifier, RuntimeIdentifier, stagingPath: stagingTarget);
+        public override Uploader CreateUploader()
+        {
+            // Temporarily fix for zstd (current default) not being supported on some systems: https://github.com/ppy/osu/issues/30175
+            // Todo: Remove with the next velopack release.
+            const string extra_args = " --compression gzip";
+
+            return new LinuxVelopackUploader(app_name, os_name, RuntimeIdentifier, RuntimeIdentifier, extraArgs: extra_args, stagingPath: stagingTarget);
+        }
 
         public override void Build()
         {


### PR DESCRIPTION
I know how this looks, but this is actually zlib:

```
(home) ~/Desktop $ dd if=old.AppImage bs=1 skip=$(./old.AppImage --appimage-offset) count=32 2>/dev/null | file -
/dev/stdin: Squashfs filesystem, little endian, version 4.0, zlib compressed, 0 bytes, 478 inodes, blocksize: 131072 bytes, created: Thu Jan  1 00:00:00 1970
(home) ~/Desktop $ dd if=new.AppImage bs=1 skip=$(./new.AppImage --appimage-offset) count=32 2>/dev/null | file -
/dev/stdin: Squashfs filesystem, little endian, version 4.0, zstd compressed, 0 bytes, 472 inodes, blocksize: 131072 bytes, created: Thu Jan  1 00:00:00 1970
(home) ~/Desktop $ dd if=new2.AppImage bs=1 skip=$(./new2.AppImage --appimage-offset) count=32 2>/dev/null | file -
/dev/stdin: Squashfs filesystem, little endian, version 4.0, zlib compressed, 0 bytes, 471 inodes, blocksize: 131072 bytes, created: Thu Jan  1 00:00:00 1970
```

old = [2024.817.0](https://github.com/ppy/osu/releases/tag/2024.817.0) (pre-velopack)
new = 2024.1009.1 (pulled)
new2 = this PR