### PR TITLE
Use vpk package with old AppImage runtime

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "vpk": {
-      "version": "0.0.630-g9c52e40",
+    "smgi.vpk": {
+      "version": "0.0.754-g7e9735c",
       "commands": [
         "vpk"
       ]


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30187

It turns out that the new AppImage runtime does not play nice with an external tool called AppImageLauncher, which simply doesn't seem to support the type-2 runtime: https://github.com/AppImage/type2-runtime/issues/12

Resulting in many projects experiencing the same/similar issues:
- https://github.com/TheAssassin/AppImageLauncher/issues/657
- https://github.com/TheAssassin/AppImageLauncher/issues/656
- https://github.com/TheAssassin/AppImageLauncher/issues/602
- https://github.com/TheAssassin/AppImageLauncher/issues/599
- https://github.com/TheAssassin/AppImageLauncher/issues/593
- https://github.com/TheAssassin/AppImageLauncher/issues/586
- https://github.com/TheAssassin/AppImageLauncher/issues/564

And now, osu!.

Velopack switched to type-2 upon request, because we wanted to use `zstd` compression. This was my mistake, because we were actually using `zlib` (which is mapped to by [`gzip`](https://github.com/ppy/osu-deploy/blob/43b570ee996e11501f98dcfddb816e24a82b882c/Builders/LinuxBuilder.cs#L30-L32)). The PRs involved were:
- https://github.com/velopack/velopack/pull/237
- https://github.com/velopack/velopack/pull/238
- https://github.com/velopack/velopack/pull/243

I will be PRing the revert to Velopack upstream, but in the meantime I've built a custom package from https://github.com/smoogipoo/velopack/tree/revert-type2-runtime + https://github.com/smoogipoo/velopack/actions/runs/11274894456

@peppy I intend to rebuild the existing release on Linux ASAP to prevent more issues like https://github.com/ppy/osu/issues/30187

I have tested that it runs, but I don't have AppImageLauncher installed so have not reproed the original issue.