### PR TITLE
Update Velopack to `0.0.915`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "vpk": {
-      "version": "0.0.755-g7719c71",
+      "version": "0.0.915",
       "commands": [
         "vpk"
       ]


### PR DESCRIPTION
I haven't tested the full update flow, but this version doesn't link `UpdateNix` to libssl.

See also: https://github.com/ppy/osu/pull/30659