### PR TITLE
Disable macOS "Game Mode" feature for now

### DIFF
--- a/templates/osu!.app/Contents/Info.plist
+++ b/templates/osu!.app/Contents/Info.plist
@@ -95,7 +95,11 @@
 			<false/>
 		</dict>
 	</array>
+	<!-- Game Mode causes occasional input hang-ups on macOS, 
+	     comment out application category to disable it for now.
+	 	 This should be revisited once osu! can handle input without the window event flow,
+	 	 see: https://github.com/ppy/osu-framework/issues/6141
 	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.music-games</string>
+	<string>public.app-category.music-games</string> -->
 </dict>
 </plist>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/30565

Unfortunately, macOS enforces game mode whenever it sees any app in the "games" category, so the only way to disable game mode is to move away from such category for now. I've just commented out the specification, leaving the app as it used to be before game mode was enabled.

Note that, frustratingly, there might be a chance for "Game Mode" to still be enabled in future updates of osu!, I have no idea why it's happening but after spending a lot of time trying to figure it out I just gave up and rolled on with this change and hoping it just works.

I've kept iOS for now as I don't think it suffers that much, but I guess time will tell.