### PR TITLE
remove linux thumbnailing

### DIFF
--- a/templates/osu!.AppDir/AppRun
+++ b/templates/osu!.AppDir/AppRun
@@ -1,12 +1,5 @@
 #!/bin/sh
 
-if [ ! -z "$APPIMAGE" ] && [ ! -z "$APPDIR" ]; then
-    MD5=$(echo -n "file://$APPIMAGE" | md5sum | cut -d' ' -f1)
-    cp "$APPDIR/osu!.png" "$HOME/.cache/thumbnails/normal/$MD5.png"
-    cp "$APPDIR/osu!.png" "$HOME/.cache/thumbnails/large/$MD5.png"
-    xdg-icon-resource forceupdate
-fi
-
 HERE="$(dirname "$(readlink -f "${0}")")"
 export PATH="${HERE}"/usr/bin/:"${PATH}"
 EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2 | cut -d " " -f 1)


### PR DESCRIPTION
This removes the logic where osu! tries to thumbnail itself, I have a few reasons for this and also this is urgent after #181 was merged which changed `osu!.png` to `osu.png` I missed this one, so before we end up with a broken release let's settle this.

Thumbnailing is usually the job of the file manager and whatever thumbnailing plugins it has, so this doesn't look like a good idea

* for one it only thumbnails after launching the game, otherwise it won't have the icon
* it also made me a bit confused in regards to https://github.com/ppy/osu/issues/30759 where the user's file manager thumbnailing was failing due to an entirely different issue, which also made me aware kde can thumbnail appimages for example, so this is not our job.