### PR TITLE
create .DirIcon symbolic link

### DIFF
--- a/Builders/LinuxBuilder.cs
+++ b/Builders/LinuxBuilder.cs
@@ -69,6 +69,8 @@ namespace osu.Desktop.Deploy.Builders
 
             CopyDirectory(Path.Combine(Program.TemplatesPath, app_dir), stagingTarget, true);
 
+            File.CreateSymbolicLink(Path.Combine(stagingTarget, ".DirIcon"), "osu.png");
+
             Program.RunCommand("chmod", $"+x {stagingTarget}/AppRun");
 
             RunDotnetPublish(outputDir: publishTarget);


### PR DESCRIPTION
Continuing on https://github.com/ppy/osu/issues/30759 I was waiting for Velopack to address this and they did at https://github.com/velopack/velopack/pull/390

However, they decided to only do it for apps that use the default Velopack template, since osu! uses a custom AppDir, we'll need to comply with the AppDir spec on our own.

This creates a `.DirIcon` symbolic link to `osu.png` bringing us back to how `appimagetool` used to handle it before the Velopack migration.

I did end up using a symbolic link to follow `appimagetool` but Velopack seemed to have adopted a copy operation instead, just to note. I just felt like a symbolic link made more sense instead of duplicating files and to follow the original `appimagetool`