### PR TITLE
Include pre-release assets in generating deltas

### DIFF
--- a/Uploaders/VelopackUploader.cs
+++ b/Uploaders/VelopackUploader.cs
@@ -35,7 +35,8 @@ namespace osu.Desktop.Deploy.Uploaders
                                              + $" --repoUrl=\"{Program.GitHubRepoUrl}\""
                                              + $" --token=\"{Program.GitHubAccessToken}\""
                                              + $" --channel=\"{channel}\""
-                                             + $" --outputDir=\"{Program.ReleasesPath}\"",
+                                             + $" --outputDir=\"{Program.ReleasesPath}\""
+                                             + " --pre",
                     throwIfNonZero: false,
                     useSolutionPath: false);
             }


### PR DESCRIPTION
Note that this intentionally does _not_ set the pre-release flag on **uploads**. I consider that flag optional (something @peppy would set if required for a particular release) rather than the default. Let me know if you'd like this changed.

This isn't required for https://github.com/ppy/osu/pull/33162 to work, but without this it means pre-release versions would be diffed against stable releases and may require full updates if there's multiple in a row.