### PR TITLE
Add `disable-library-validation` entitlement to fix Satori on osx-x64

### DIFF
--- a/osu.entitlements
+++ b/osu.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
-	<true/>
-	<key>com.apple.security.cs.allow-jit</key>
-	<true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
I've gone super deep into this. Enough so that I can't write up everything I've done to try and resolve the issue, and at the end of the day I have _no idea_ why things are as they are. I'll try to condense my findings.

Here's a test. Download the latest Tachyon release and perform the following using the entitlements on `master`:
```sh
> xattr -dr com.apple.quarantine osu\!b.app

> codesign -f -s - --entitlements ~/Repos/osu-deploy/osu.entitlements -o runtime --deep osu\!b.app
osu!b.app: replacing existing signature

> ./osu\!b.app/Contents/MacOS/osu\!
Failed to load /Users/smgi/Downloads/osu!b.app/Contents/MacOS/libhostfxr.dylib, error: dlopen(/Users/smgi/Downloads/osu!b.app/Contents/MacOS/libhostfxr.dylib, 0x0001): tried: '/Users/smgi/Downloads/osu!b.app/Contents/MacOS/libhostfxr.dylib' (code signature in <FDA96162-34BD-3443-9267-5E39A0CABDC2> '/Users/smgi/Downloads/osu!b.app/Contents/MacOS/libhostfxr.dylib' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs), '/System/Volumes/Preboot/Cryptexes/OS/Users/smgi/Downloads/osu!b.app/Contents/MacOS/libhostfxr.dylib' (no such file), '/Users/smgi/Downloads/osu!b.app/Contents/MacOS/libhostfxr.dylib' (code signature in <FDA96162-34BD-3443-9267-5E39A0CABDC2> '/Users/smgi/Downloads/osu!b.app/Contents/MacOS/libhostfxr.dylib' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs)
The library libhostfxr.dylib was found, but loading it from /Users/smgi/Downloads/osu!b.app/Contents/MacOS/libhostfxr.dylib failed
  - Installing .NET prerequisites might help resolve this problem.
     https://go.microsoft.com/fwlink/?linkid=2063366
```

Now, using the entitlements in this PR:
```sh
> $ codesign -f -s - --entitlements ~/Repos/osu-deploy/osu.entitlements -o runtime --deep osu\!b.app
osu!b.app: replacing existing signature

> $ ./osu\!b.app/Contents/MacOS/osu\!
# Runs!
```

Now, the error from the first attempt is still different from what happens if you try to run the app directly after downloading, which is:
```
Failed to create CoreCLR, HRESULT: 0x8007000C
```
I don't know exactly why this is but I expect it's due to the adhoc signature. I can reproduce this error using my developer certificate. Thus, I'm only using the above as a demonstration that _simply changing the entitlements_ fixes the issue.

From what I can surmise:
- The error only happens on `osx-x64` or Rosetta, and to fix it we need to add this entitlement.
- The entitlement is itself stated as a requirement for .NET: https://learn.microsoft.com/en-au/dotnet/core/install/macos-notarization-issues#default-entitlements At least, it's stated as a requirement for the "appHost" which would be the `osu!` executable itself, but it likely goes beyond that for the case where you replace more than just the host. [.NET Entitlements](https://github.com/dotnet/runtime/blob/main/eng/native/entitlements.plist).
- Why does the app work when we don't provide the entitlement? I haven't figured this one out. The thing is, the output of `codesign -d --entitlements - osu\!.app/Contents/MacOS/libcoreclr.dylib` **don't include** that entitlement on either release. As far as every tool I've used can tell me, the two files look practically identical between the releases. I'd expect that re-signing would lock down the app further, yet...
- I recognise that this entitlement seems sketchy to add, but there is precedent for this being done [[1]](https://github.com/martincostello/dotnet-macos-notarization-example/blob/main/src/HelloWorld/HelloWorld.entitlements) [[2]](https://docs.avaloniaui.net/docs/deployment/macOS) [[3]](https://github.com/dotnet/sdk/issues/24337#issuecomment-1252890457) [[4]](https://github.com/pyinstaller/pyinstaller/issues/4629#issuecomment-583785114) [[5]](https://github.com/electron-userland/electron-builder/issues/3940).