### PR TITLE
Include (x64) architecture in Windows & Linux release filenames

### DIFF
--- a/Builders/WindowsBuilder.cs
+++ b/Builders/WindowsBuilder.cs
@@ -12,7 +12,6 @@ namespace osu.Desktop.Deploy.Builders
     {
         private const string app_name = "osu!.exe";
         private const string os_name = "win";
-        private const string channel = "win";
 
         public WindowsBuilder(string version)
             : base(version)
@@ -52,7 +51,7 @@ namespace osu.Desktop.Deploy.Builders
                     $" --signTemplate=\"\\\"{signToolPath}\\\" sign /td sha256 /fd sha256 /dlib \\\"{dllPath}\\\" /dmdf \\\"{Path.GetFullPath(Program.WindowsCodeSigningMetadataPath)}\\\" /tr http://timestamp.acs.microsoft.com {{{{file...}}}}";
             }
 
-            return new WindowsVelopackUploader(app_name, os_name, RuntimeIdentifier, channel, extraArgs: extraArgs);
+            return new WindowsVelopackUploader(app_name, os_name, RuntimeIdentifier, RuntimeIdentifier, extraArgs: extraArgs);
         }
 
         public override void Build()

--- a/Uploaders/LinuxVelopackUploader.cs
+++ b/Uploaders/LinuxVelopackUploader.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
+
 namespace osu.Desktop.Deploy.Uploaders
 {
     public class LinuxVelopackUploader : VelopackUploader
@@ -16,7 +19,13 @@ namespace osu.Desktop.Deploy.Uploaders
         public override void PublishBuild(string version)
         {
             base.PublishBuild(version);
-            RenameAsset($"{Program.PackageName}-{channel}.AppImage", "osu.AppImage");
+
+            if (channel != "linux-x64")
+                throw new Exception($"Unrecognised channel: {channel}");
+
+            string suffix = channel.Split('-').Last();
+
+            RenameAsset($"{Program.PackageName}-{channel}.AppImage", $"osu-{suffix}.AppImage");
         }
     }
 }

--- a/Uploaders/WindowsVelopackUploader.cs
+++ b/Uploaders/WindowsVelopackUploader.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
+
 namespace osu.Desktop.Deploy.Uploaders
 {
     public class WindowsVelopackUploader : VelopackUploader
@@ -18,7 +21,13 @@ namespace osu.Desktop.Deploy.Uploaders
         public override void PublishBuild(string version)
         {
             base.PublishBuild(version);
-            RenameAsset($"{Program.PackageName}-{channel}-Setup.exe", "install.exe");
+
+            if (channel != "win-x64")
+                throw new Exception($"Unrecognised channel: {channel}");
+
+            string suffix = channel.Split('-').Last();
+
+            RenameAsset($"{Program.PackageName}-{channel}-Setup.exe", $"install-{suffix}.exe");
         }
     }
 }


### PR DESCRIPTION
In preparation for #192 split this out as these are the changes which could also affect non-ARM64 parts of the releases. I'm not sure just how large of an effect the following [release asset renames](https://github.com/ppy/osu/releases/tag/2025.912.0-lazer) will have but if I had to guess it'll be big and should be done carefully (to accomodate the future `-arm64` variants).
| Before | After |
| :---: | :---: |
| `RELEASES` | `RELEASES-win-x64` |
| `releases.win.json` | `releases.win-x64.json` |
| `*-lazer-full.nupkg` | `*-lazer-win-x64-full.nupkg` |
| `*-lazer-delta.nupkg` | `*-lazer-win-x64-delta.nupkg` |
| `osulazer-win-Setup.exe` | `osulazer-win-x64-Setup.exe` |
| ` osu.AppImage ` | `osu-x64.AppImage` |

This will of course not potentially just affect the [in-game updater](https://github.com/ppy/osu/tree/master/osu.Game/Updater) but also the [README](https://github.com/ppy/osu#latest-release), [website](https://osu.ppy.sh/home/download), [flatpak](https://github.com/flathub/sh.ppy.osu) and possibly more I'm not even aware of yet.