### PR TITLE
Fixed incorrect app icon key name in info.plist

### DIFF
--- a/templates/osu!.app/Contents/Info.plist
+++ b/templates/osu!.app/Contents/Info.plist
@@ -12,7 +12,7 @@
 	<string>osu-lazer</string>
 	<key>CFBundleIconFile</key>
 	<string>AppIcon</string>
-	<key>CFBundleIconFileName</key>
+	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>sh.ppy.osu.lazer</string>


### PR DESCRIPTION
Small typo on my behalf that was causing the high resolution variants of the icon to be ignored. Sorry about that!

<img width="825" height="640" alt="Screenshot 2026-01-29 at 5 53 39 PM" src="https://github.com/user-attachments/assets/a8a79189-0a98-4103-920b-551ebc626357" />
